### PR TITLE
Make the plugin enabled by default after install

### DIFF
--- a/ddb_gnome_mmkeys.c
+++ b/ddb_gnome_mmkeys.c
@@ -35,6 +35,7 @@
 
 #include <unistd.h>
 #include <stdio.h>
+#include <string.h>
 #include <gio/gio.h>
 #include <glib.h>
 #include <deadbeef/deadbeef.h>
@@ -240,7 +241,7 @@ DB_mmkeys_plugin plugin = {
       .exec_cmdline =  NULL, // command line processing function
       .get_actions =   NULL, // linked list of actions function
       .message =       NULL, // message processing function
-      .configdialog =  "property \"Enable\" checkbox ddb_gnome_mmkeys.enable 0;\n"
+      .configdialog =  "property \"Enable\" checkbox ddb_gnome_mmkeys.enable 1;\n"
                        "property \"MATE support\" checkbox ddb_gnome_mmkeys.mate 0;\n" // config dialog function
     },
     .proxy = NULL,


### PR DESCRIPTION
I wondered why it didn't work after installation for a while because I know plugins do not need to be enabled after installation at deadbeef level. Hopefully this will make it more friendly to newcomers.

Also added an include on `<string.h>` so that compiler won't complain about the implicit definition of `strcmp`.